### PR TITLE
検索条件の氏名キーワードがスペースを許容しない

### DIFF
--- a/src/main/java/com/example/web/backingbean/EmployeeIndexBean.java
+++ b/src/main/java/com/example/web/backingbean/EmployeeIndexBean.java
@@ -27,7 +27,7 @@ public class EmployeeIndexBean implements Serializable {
     
     private List<EmployeeDto> employeeList;
 
-    @Pattern(regexp = "[a-zA-Z]*", message = "{pattern.alphabet.or.space}")
+    @Pattern(regexp = "[a-zA-Z\\s]*", message = "{pattern.alphabet.or.space}")
     @Size(max = 10, message = "{size.string}")
     private String name;
     @Pattern(regexp = "[1-9][0-9]*", message = "{pattern.integer}")


### PR DESCRIPTION
松井です。
今日ソースコードを取得して少し動かしてみました。
ちょっと気になったところがあったので、折角なのでプルリクエストしてみます。
（GitHub でやるの初めてなので、間違ってたらご指摘を…）。

トップページでの検索機能なのですが、半角スペースを含む文字列で検索しても「アルファベット及び半角スペースで入力してください」と表示されてしまうようです。
登録、変更画面同様、入力検証で半角スペースを許容するようにしてはいかがでしょうか。
