### PR TITLE
社員登録確認画面でのキャンセルボタンを押したときの部署名取得処理は不要か

### DIFF
--- a/src/main/java/com/example/web/backingbean/EmployeeInsertBean.java
+++ b/src/main/java/com/example/web/backingbean/EmployeeInsertBean.java
@@ -60,7 +60,6 @@ public class EmployeeInsertBean implements Serializable {
     }
     
     public String cancel() {
-        deptName = departmentService.findById(Integer.valueOf(deptId)).getName();
         return "insert.xhtml";
     }
     


### PR DESCRIPTION
もう一つ。
登録確認画面でキャンセルボタンを押したときの処理として部署名を取得しているのですが、登録画面では部署名は使用しないので、これは不要ではないかなと思いました。
